### PR TITLE
find_venv_bin function to common.py

### DIFF
--- a/pyempaq/common.py
+++ b/pyempaq/common.py
@@ -4,6 +4,7 @@
 
 """Common functionality for packer and unpucker modules."""
 
+
 def find_venv_bin(basedir, exec_base):
     """Heuristics to find the pip executable in different platforms."""
     bin_dir = basedir / "bin"
@@ -17,4 +18,3 @@ def find_venv_bin(basedir, exec_base):
         return bin_dir / f"{exec_base}.exe"
 
     raise RuntimeError(f"Binary not found inside venv; subdirs: {list(basedir.iterdir())}")
-

--- a/pyempaq/common.py
+++ b/pyempaq/common.py
@@ -1,8 +1,8 @@
-# Copyright 2021 Facundo Batista
+# Copyright 2022 Facundo Batista
 # Licensed under the GPL v3 License
 # For further info, check https://github.com/facundobatista/pyempaq
 
-"""Common functionality."""
+"""Common functionality for packer and unpucker modules."""
 
 def find_venv_bin(basedir, exec_base):
     """Heuristics to find the pip executable in different platforms."""

--- a/pyempaq/common.py
+++ b/pyempaq/common.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Facundo Batista
+# Licensed under the GPL v3 License
+# For further info, check https://github.com/facundobatista/pyempaq
+
+"""Common functionality."""
+
+def find_venv_bin(basedir, exec_base):
+    """Heuristics to find the pip executable in different platforms."""
+    bin_dir = basedir / "bin"
+    if bin_dir.exists():
+        # linux-like environment
+        return bin_dir / exec_base
+
+    bin_dir = basedir / "Scripts"
+    if bin_dir.exists():
+        # windows environment
+        return bin_dir / f"{exec_base}.exe"
+
+    raise RuntimeError(f"Binary not found inside venv; subdirs: {list(basedir.iterdir())}")
+

--- a/pyempaq/main.py
+++ b/pyempaq/main.py
@@ -7,6 +7,7 @@
 import argparse
 import json
 import pathlib
+import os
 import shutil
 import subprocess
 import sys
@@ -16,6 +17,7 @@ import venv
 import zipapp
 from collections import namedtuple
 
+from pyempaq.common import find_venv_bin
 from pyempaq.config_manager import load_config, ConfigError
 
 # collected arguments
@@ -24,21 +26,6 @@ Args = namedtuple("Args", "project_name basedir entrypoint requirement_files")
 
 class ExecutionError(Exception):
     """The subprocess didn't finish ok."""
-
-
-def find_venv_bin(basedir, exec_base):
-    """Heuristics to find the pip executable in different platforms."""
-    bin_dir = basedir / "bin"
-    if bin_dir.exists():
-        # linux-like environment
-        return bin_dir / exec_base
-
-    bin_dir = basedir / "Scripts"
-    if bin_dir.exists():
-        # windows environment
-        return bin_dir / f"{exec_base}.exe"
-
-    raise RuntimeError(f"Binary not found inside venv; subdirs: {list(basedir.iterdir())}")
 
 
 def logged_exec(cmd):
@@ -88,6 +75,12 @@ def pack(config):
     # copy all the project content inside "orig" in temp dir
     origdir = tmpdir / "orig"
     shutil.copytree(config.basedir, origdir)
+
+    # copy the common module
+    os.mkdir(f"{tmpdir}/pyempaq")
+    common_src = pathlib.Path(__file__).parent / "common.py"
+    common_final_src = tmpdir / "pyempaq/common.py"
+    shutil.copy(common_src, common_final_src)
 
     # copy the unpacker as the entry point of the zip
     unpacker_src = pathlib.Path(__file__).parent / "unpacker.py"

--- a/pyempaq/main.py
+++ b/pyempaq/main.py
@@ -7,7 +7,6 @@
 import argparse
 import json
 import pathlib
-import os
 import shutil
 import subprocess
 import sys
@@ -69,6 +68,7 @@ def get_pip():
 
 def pack(config):
     """Pack."""
+    project_root = pathlib.Path(__file__).parent
     tmpdir = pathlib.Path(tempfile.mkdtemp())
     print(f"DEBUG packer: working in temp dir {str(tmpdir)!r}")
 
@@ -77,13 +77,14 @@ def pack(config):
     shutil.copytree(config.basedir, origdir)
 
     # copy the common module
-    os.mkdir(f"{tmpdir}/pyempaq")
-    common_src = pathlib.Path(__file__).parent / "common.py"
-    common_final_src = tmpdir / "pyempaq/common.py"
+    pyempaq_dir = tmpdir / "pyempaq"
+    pyempaq_dir.mkdir()
+    common_src = project_root / "common.py"
+    common_final_src = tmpdir / "pyempaq" / "common.py"
     shutil.copy(common_src, common_final_src)
 
     # copy the unpacker as the entry point of the zip
-    unpacker_src = pathlib.Path(__file__).parent / "unpacker.py"
+    unpacker_src = project_root / "unpacker.py"
     unpacker_final_main = tmpdir / "__main__.py"
     shutil.copy(unpacker_src, unpacker_final_main)
 

--- a/pyempaq/unpacker.py
+++ b/pyempaq/unpacker.py
@@ -14,25 +14,12 @@ import venv
 import zipfile
 from typing import List, Dict
 
+from pyempaq.common import find_venv_bin
+
 
 # this is the directory for the NEW virtualenv created for the project (not the packed
 # one to run unpacker itself)
 PROJECT_VENV_DIR = "project_venv"
-
-
-def find_venv_bin(basedir, exec_base):
-    """Heuristics to find the pip executable in different platforms."""
-    bin_dir = basedir / "bin"
-    if bin_dir.exists():
-        # linux-like environment
-        return bin_dir / exec_base
-
-    bin_dir = basedir / "Scripts"
-    if bin_dir.exists():
-        # windows environment
-        return bin_dir / "{}.exe".format(exec_base)
-
-    raise RuntimeError("Binary not found inside venv; subdirs: {}".format(list(basedir.iterdir())))
 
 
 def log(template, *args):


### PR DESCRIPTION
#10 

En `pack()` del file `main.py` creamos la carpeta `tmpdir/pyempaq/` que nos habilita poder hacer 
```
from pyempaq.common import find_venv_bin 
```
tanto en main como en el unpacker.

De este modo pasan OK los test integration y unpacker
 