### PR TITLE
Allow to specify min python version

### DIFF
--- a/pyempaq/config_manager.py
+++ b/pyempaq/config_manager.py
@@ -144,7 +144,7 @@ class Config(ModelConfigDefaults, validate_all=False):
 
     @pydantic.validator("unpack_restrictions", pre=True)
     def validate_unpack_restrictions(cls, value):
-        """Ensure the unpack_restrictions is valid."""
+        """Ensure unpack_restrictions are valid."""
         python_version = value["minimum_python_version"]
 
         if not isinstance(python_version, str):

--- a/pyempaq/config_manager.py
+++ b/pyempaq/config_manager.py
@@ -108,6 +108,7 @@ class Config(ModelConfigDefaults, validate_all=False):
     exec: Executor
     requirements: List[RelativeFile] = []
     dependencies: List[str] = []
+    unpack_restrictions: dict = {}
 
     @pydantic.validator("basedir")
     def ensure_basedir(cls, value):
@@ -140,6 +141,15 @@ class Config(ModelConfigDefaults, validate_all=False):
             subkeys_str = ', '.join(repr(x) for x in subkeys)
             raise ValueError(f"only one of these subkeys is allowed: {subkeys_str}")
         return values
+
+    @pydantic.validator("unpack_restrictions", pre=True)
+    def validate_unpack_restrictions(cls, value):
+        """Ensure the unpack_restrictions is valid."""
+        python_version = value["minimum_python_version"]
+
+        if not isinstance(python_version, str):
+            raise ValueError(f"{python_version!r} must be a string")
+        return value
 
 
 def _format_pydantic_errors(errors):

--- a/pyempaq/main.py
+++ b/pyempaq/main.py
@@ -110,6 +110,7 @@ def pack(config):
         "requirement_files": [str(path) for path in config.requirements],
         "project_name": config.name,
         "exec_default_args": config.exec.default_args,
+        "unpack_restrictions": config.unpack_restrictions
     }
     if config.exec.script is not None:
         metadata["exec_style"] = "script"

--- a/pyempaq/unpacker.py
+++ b/pyempaq/unpacker.py
@@ -86,6 +86,19 @@ def run():
     pyempaq_dir.mkdir(parents=True, exist_ok=True)
     log("Temp base dir: {!r}", str(pyempaq_dir))
 
+    # Check unpack restrictions
+
+    current_version = 3.8  # TODO - from pkg_resources import parse_version
+
+    if min_py_version := metadata["unpack_restrictions"]["minimum_python_version"]:
+        if current_version < min_py_version:
+            warning_msg = "WARNING: Unsupported Python version, the minimum required is {!r}", str(current_version)
+            if os.environ.get("PYEMPAQ_IGNORE_RESTRICTIONS"):
+                log(warning_msg)
+                log("Ommited because PYEMPAQ_IGNORE_RESTRICTIONS is set")
+            else:
+                raise ValueError(warning_msg)
+
     # create a temp dir and extract the project there
     timestamp = time.strftime("%Y%m%d%H%M%S", time.gmtime(pyempaq_filepath.stat().st_ctime))
     project_dir = pyempaq_dir / "{}-{}".format(metadata["project_name"], timestamp)
@@ -116,6 +129,8 @@ def run():
             log("Skipping virtualenv (no requirements)")
 
     python_exec = get_python_exec(project_dir)
+
+
     os.chdir(original_project_dir)
 
     cmd = build_command(str(python_exec), metadata, sys.argv[1:])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -57,6 +57,8 @@ def test_basic_cycle_full(tmp_path):
         basedir: {projectpath}
         exec:
           script: ep.py
+        unpack_restrictions:
+          minimum_python_version: "3.8"
     """))
 
     # pack it calling current pyempaq externally

--- a/tests/test_load_config.py
+++ b/tests/test_load_config.py
@@ -163,6 +163,23 @@ def test_basedir_missing(tmp_path):
     ]
 
 
+def test_minimum_req_version_not_a_string(tmp_path):
+    """The minimum_python_version must be a string."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("""
+        name: testproject
+        unpack_restrictions:
+            minimum_python_version: 3.8
+    """)
+
+    with pytest.raises(ConfigError) as cm:
+        load_config(config_file)
+    assert cm.value.errors == [
+        "- 'exec': field required",
+        "- 'unpack_restrictions': 3.8 must be a string",
+    ]
+
+
 # -- check the different exec entries
 
 def test_exec_script_ok_relative(tmp_path):


### PR DESCRIPTION
Fixes #29 

Se agrega opción para especificar versión de Python miníma para ejecutar el **.pyz**

TODO:

- [ ] Agregar este minimum_version a la metadata para ser usada en el unpacking
- [ ] Agregar lógica para el unpacking
- [ ] Documentar