### PR TITLE
moves logged_exec from main.py to common.py

### DIFF
--- a/pyempaq/common.py
+++ b/pyempaq/common.py
@@ -4,6 +4,16 @@
 
 """Common functionality for packer and unpucker modules."""
 
+import logging
+import subprocess
+
+
+logger = logging.getLogger('logger')
+
+
+class ExecutionError(Exception):
+    """The subprocess didn't finish ok."""
+
 
 def find_venv_bin(basedir, exec_base):
     """Heuristics to find the pip executable in different platforms."""
@@ -18,3 +28,23 @@ def find_venv_bin(basedir, exec_base):
         return bin_dir / f"{exec_base}.exe"
 
     raise RuntimeError(f"Binary not found inside venv; subdirs: {list(basedir.iterdir())}")
+
+
+def logged_exec(cmd):
+    """Execute a command, redirecting the output to the log."""
+    cmd = list(map(str, cmd))
+    logger.debug(f"Executing external command: {cmd}")
+    try:
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+    except Exception as err:
+        raise ExecutionError(f"Command {cmd} crashed with {err!r}")
+    stdout = []
+    for line in proc.stdout:
+        line = line[:-1]
+        stdout.append(line)
+        logger.debug(f":: {line}")
+    retcode = proc.wait()
+    if retcode:
+        raise ExecutionError(f"Command {cmd} ended with retcode {retcode}")
+    return stdout

--- a/pyempaq/main.py
+++ b/pyempaq/main.py
@@ -6,18 +6,17 @@
 
 import argparse
 import json
+import logging
 import pathlib
 import shutil
-import subprocess
 import sys
 import tempfile
 import uuid
 import venv
 import zipapp
 from collections import namedtuple
-import logging
 
-from pyempaq.common import find_venv_bin
+from pyempaq.common import find_venv_bin, logged_exec, ExecutionError
 from pyempaq.config_manager import load_config, ConfigError
 
 
@@ -30,30 +29,6 @@ logger = logging.getLogger(__name__)
 
 # collected arguments
 Args = namedtuple("Args", "project_name basedir entrypoint requirement_files")
-
-
-class ExecutionError(Exception):
-    """The subprocess didn't finish ok."""
-
-
-def logged_exec(cmd):
-    """Execute a command, redirecting the output to the log."""
-    cmd = list(map(str, cmd))
-    logger.debug(f"Executing external command: {cmd}")
-    try:
-        proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
-    except Exception as err:
-        raise ExecutionError(f"Command {cmd} crashed with {err!r}")
-    stdout = []
-    for line in proc.stdout:
-        line = line[:-1]
-        stdout.append(line)
-        logger.debug(f":: {line}")
-    retcode = proc.wait()
-    if retcode:
-        raise ExecutionError(f"Command {cmd} ended with retcode {retcode}")
-    return stdout
 
 
 def get_pip():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
 flake8
+logassert
 pydocstyle
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ flake8
 logassert
 pydocstyle
 pytest
+pytest-subprocess

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,6 +6,7 @@
 
 import logging
 import pytest
+import sys
 
 from pyempaq.common import logged_exec, find_venv_bin
 
@@ -49,8 +50,10 @@ def test_logged_exec_error():
     assert "Command ['pip_bar', 'pip_baz'] crashed with " in str(e.value)
 
 
-def test_logged_exec_wait():
+def test_logged_exec_retcode():
     """Execute a command and ended with some return code."""
+    cmd_OS = ['dir', 'foo'] if sys.platform == "win32" else ['ls', 'foo']
     with pytest.raises(Exception) as e:
-        logged_exec(['dir', '$?'])
-    assert str(e.value) == "Command ['dir', '$?'] ended with retcode 2"
+        logged_exec(cmd_OS)
+
+    assert str(e.value) == f"Command {cmd_OS} ended with retcode 2"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,9 +4,10 @@
 
 """Common functions module tests."""
 
+import logging
 import pytest
 
-from pyempaq.common import find_venv_bin
+from pyempaq.common import logged_exec, find_venv_bin
 
 
 def test_find_venv_bin_l(tmp_path):
@@ -29,3 +30,27 @@ def test_find_venv_bin_no(tmp_path):
     """Can't find directory for the executable and raise RuntimeError."""
     with pytest.raises(RuntimeError):
         find_venv_bin(tmp_path, "pip_baz")
+
+
+def test_logged_exec(caplog):
+    """Execute a command, redirecting the output to the log. Everything OK."""
+    with caplog.at_level(logging.DEBUG):
+        stdout = logged_exec(['echo', 'test'])
+
+    assert stdout == ['test']
+    assert "Executing external command: ['echo', 'test']" in caplog.text
+
+
+def test_logged_exec_error():
+    """Execute a command, raises an error."""
+    with pytest.raises(Exception) as e:
+        logged_exec(["pip_bar", "pip_baz"])
+
+    assert "Command ['pip_bar', 'pip_baz'] crashed with " in str(e.value)
+
+
+def test_logged_exec_wait():
+    """Execute a command and ended with some return code."""
+    with pytest.raises(Exception) as e:
+        logged_exec(['dir', '$?'])
+    assert str(e.value) == "Command ['dir', '$?'] ended with retcode 2"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -36,7 +36,6 @@ def test_logged_exec(logs):
     """Execute a command, redirecting the output to the log. Everything OK."""
     logged_exec(['echo', 'test'])
 
-    assert 'test' in logs.debug
     assert Exact("Executing external command: ['echo', 'test']") in logs.debug
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,7 +6,6 @@
 
 from logassert import Exact
 import pytest
-import sys
 
 from pyempaq.common import logged_exec, find_venv_bin
 
@@ -41,18 +40,19 @@ def test_logged_exec(logs):
     assert Exact("Executing external command: ['echo', 'test']") in logs.debug
 
 
-def test_logged_exec_error():
+def test_logged_exec_error(fp):
     """Execute a command, raises an error."""
     with pytest.raises(Exception) as e:
-        logged_exec(["pip_bar", "pip_baz"])
+        logged_exec(["pip_baz"])
 
-    assert "Command ['pip_bar', 'pip_baz'] crashed with " in str(e.value)
+    assert str(e.value)[:32] == "Command ['pip_baz'] crashed with"
 
 
-def test_logged_exec_retcode():
+def test_logged_exec_retcode(fp):
     """Execute a command and ended with some return code."""
-    cmd_OS = ['dir', 'foo'] if sys.platform == "win32" else ['ls', 'foo']
-    with pytest.raises(Exception) as e:
-        logged_exec(cmd_OS)
+    fp.register(['pip_foo'], returncode=1800)
 
-    assert str(e.value)[:-1] == f"Command {cmd_OS} ended with retcode "
+    with pytest.raises(Exception) as e:
+        logged_exec(['pip_foo'])
+
+    assert str(e.value) == "Command ['pip_foo'] ended with retcode 1800"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,7 +4,7 @@
 
 """Common functions module tests."""
 
-import logging
+from logassert import Exact
 import pytest
 import sys
 
@@ -33,13 +33,12 @@ def test_find_venv_bin_no(tmp_path):
         find_venv_bin(tmp_path, "pip_baz")
 
 
-def test_logged_exec(caplog):
+def test_logged_exec(logs):
     """Execute a command, redirecting the output to the log. Everything OK."""
-    with caplog.at_level(logging.DEBUG):
-        stdout = logged_exec(['echo', 'test'])
+    logged_exec(['echo', 'test'])
 
-    assert stdout == ['test']
-    assert "Executing external command: ['echo', 'test']" in caplog.text
+    assert 'test' in logs.debug
+    assert Exact("Executing external command: ['echo', 'test']") in logs.debug
 
 
 def test_logged_exec_error():

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -34,12 +34,13 @@ def test_find_venv_bin_no(tmp_path):
 
 def test_logged_exec(logs):
     """Execute a command, redirecting the output to the log. Everything OK."""
-    logged_exec(['echo', 'test'])
+    stdout = logged_exec(['echo', 'test', '123'])
 
-    assert Exact("Executing external command: ['echo', 'test']") in logs.debug
+    assert stdout == ['test 123']
+    assert Exact("Executing external command: ['echo', 'test', '123']") in logs.debug
 
 
-def test_logged_exec_error(fp):
+def test_logged_exec_error(fake_process):
     """Execute a command, raises an error."""
     with pytest.raises(Exception) as e:
         logged_exec(["pip_baz"])
@@ -47,9 +48,9 @@ def test_logged_exec_error(fp):
     assert str(e.value)[:32] == "Command ['pip_baz'] crashed with"
 
 
-def test_logged_exec_retcode(fp):
+def test_logged_exec_retcode(fake_process):
     """Execute a command and ended with some return code."""
-    fp.register(['pip_foo'], returncode=1800)
+    fake_process.register(['pip_foo'], returncode=1800)
 
     with pytest.raises(Exception) as e:
         logged_exec(['pip_foo'])

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -56,4 +56,4 @@ def test_logged_exec_retcode():
     with pytest.raises(Exception) as e:
         logged_exec(cmd_OS)
 
-    assert str(e.value) == f"Command {cmd_OS} ended with retcode 2"
+    assert str(e.value)[:-1] == f"Command {cmd_OS} ended with retcode "

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -10,7 +10,8 @@ from unittest.mock import patch
 
 import pytest
 
-from pyempaq.main import get_pip, ExecutionError
+from pyempaq.main import get_pip
+from pyempaq.common import ExecutionError
 
 
 @pytest.mark.parametrize("version", [


### PR DESCRIPTION
#11 
Además de la función `logged_exec()` moví la clase `ExecutionError` porque si la quiero importar desde `common.py` explota por la referencia circular (main --> common --> main ...).

Entiendo que el formateo del logger ya queda establecido al principio de [main.py](https://github.com/cacrespo/pyempaq/blob/refactor_logged_exec/pyempaq/main.py#L24-L25). Es decir cuando lo traigo desde [common.py](https://github.com/cacrespo/pyempaq/blob/refactor_logged_exec/pyempaq/common.py#L11) no es necesario volver a setear eso ¿cierto?

Por último, en relación al test debería chequear tres situaciones:
- se ejecutó un comando cualquiera y fue todo OK.
- se ejecutó un comando y lanzó error
- se ejecutó un comando ~y se quedó esperando una respuesta (y lo tomamos como un error)~, finalizó y retornó "distinto a 0".

¿es así?