### PR TITLE
control default verbosity in unpacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,13 @@ Examples:
 
 - `pyempaq ~/repo/proj/config.yaml`
 
-**Note**: [in the future](https://github.com/facundobatista/pyempaq/issues/8) we will be able to control verbosity, we're not there yet.
+You can control verbosity by adding these command line parameters to control logging levels:
+
+- `-v, --verbose` - Show detailed information, typically of interest only when diagnosing problems.
+- `-q, --quiet` - Only events of WARNING level and above will be tracked.
+
+> **Note**
+> In the **execution phase**, if you have an environment variable `PYEMPAQ_DEBUG=1` it will show the Pyempaq log lines during the execution.
 
 
 ## The configuration file

--- a/pyempaq/unpacker.py
+++ b/pyempaq/unpacker.py
@@ -24,7 +24,9 @@ PROJECT_VENV_DIR = "project_venv"
 
 def log(template, *args):
     """Print debug lines if proper envvar is present."""
-    print("::pyempaq::", template.format(*args))
+    envar = os.environ.get("PYEMPAQ_DEBUG", 0)
+    if envar == "1":
+        print("::pyempaq::", template.format(*args))
 
 
 def get_python_exec(project_dir: pathlib.Path) -> pathlib.Path:


### PR DESCRIPTION
closes #9 

Lo probé previo
```Bash
 export PYEMPAQ_DEBUG=1
```
y funciona todo OK. Aparecen (o no) los `prints()` en pantalla según corresponda.

¿deberíamos agregar algún test al respecto?