### PR TITLE
Add a -V/--version option to just print the version and exit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ You can control verbosity by adding these command line parameters to control log
 - `-v, --verbose` - Show detailed information, typically of interest only when diagnosing problems.
 - `-q, --quiet` - Only events of WARNING level and above will be tracked.
 
+All that said, there is an special option `-V, --version` that if used will just print the version and exit.
+
 > **Note**
 > In the **execution phase**, if you have an environment variable `PYEMPAQ_DEBUG=1` it will show the Pyempaq log lines during the execution.
 

--- a/pyempaq/__init__.py
+++ b/pyempaq/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2023 Facundo Batista
+# Licensed under the GPL v3 License
+# For further info, check https://github.com/facundobatista/pyempaq
+
+from pyempaq._version import __version__, VERSION  # noqa

--- a/pyempaq/__init__.py
+++ b/pyempaq/__init__.py
@@ -2,4 +2,6 @@
 # Licensed under the GPL v3 License
 # For further info, check https://github.com/facundobatista/pyempaq
 
+"""Expose the version information at module level, as is standard."""
+
 from pyempaq._version import __version__, VERSION  # noqa

--- a/pyempaq/_version.py
+++ b/pyempaq/_version.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Facundo Batista
+# Licensed under the GPL v3 License
+# For further info, check https://github.com/facundobatista/pyempaq
+
+"""Holder of the PyEmpaq version number."""
+
+# these two will be exported at `pyempaq` module level by __init__.py; also VERSION will
+# be parsed by setup.py without needing to import the module (at moments when the
+# version is needed but the infrastructure is not in place yet)
+VERSION = (0, 2, 2)
+__version__ = '.'.join([str(x) for x in VERSION])

--- a/pyempaq/main.py
+++ b/pyempaq/main.py
@@ -15,6 +15,7 @@ import venv
 import zipapp
 from collections import namedtuple
 
+from pyempaq import __version__
 from pyempaq.common import find_venv_bin, logged_exec, ExecutionError
 from pyempaq.config_manager import load_config, ConfigError
 
@@ -127,8 +128,12 @@ def main():
         action="store_const", dest="loglevel", const=logging.DEBUG)
     parser.add_argument(
         '-q', '--quiet',
-        help="Only events of WARNING level and above will be tracked",
+        help="Only events of WARNING level and above will be tracked.",
         action="store_const", dest="loglevel", const=logging.WARNING)
+    parser.add_argument(
+        '-V', '--version',
+        help="Print the version and exit.",
+        action="version", version=__version__)
     args = parser.parse_args()
 
     if args.loglevel is not None:

--- a/run
+++ b/run
@@ -1,0 +1,5 @@
+# Copyright 2023 Facundo Batista
+# Licensed under the GPL v3 License
+# For further info, check https://github.com/facundobatista/pyempaq
+
+fades -r requirements.txt -m pyempaq -v $@ 

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,35 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 Facundo Batista
+# Copyright 2021-2023 Facundo Batista
 # Licensed under the GPL v3 License
 # For further info, check https://github.com/facundobatista/pyempaq
 
 """Setup script for PyEmpaq."""
 
+import re
 from setuptools import setup
+
+
+def get_version():
+    """Retrieves package version from the file.
+
+    This is done by parsing statically the file, not importing it as a module,
+    because the version is needed in intermediate steps where the package itself
+    is not yet available.
+    """
+    with open('pyempaq/_version.py') as fh:
+        m = re.search(r"\(([^']*)\)", fh.read())
+    if m is None:
+        raise ValueError("Unrecognized version in 'pyempaq/_version.py'")
+    return m.groups()[0].replace(', ', '.')
+
 
 with open("requirements.txt", "rt") as fh:
     install_requires = [x.strip() for x in fh]
 
 setup(
     name="pyempaq",
-    version="0.2.2",
+    version=get_version(),
     author="Facundo Batista",
     author_email="facundo@taniquetil.com.ar",
     description="A Python packer to run anywhwere any project with any virtualenv dependencies.",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 
 def get_version():
-    """Retrieves package version from the file.
+    """Retrieve the package version from the file.
 
     This is done by parsing statically the file, not importing it as a module,
     because the version is needed in intermediate steps where the package itself


### PR DESCRIPTION
Fixes #25. Supersedes #28 and #39.

The version is simply hold in a separate file. When running PyEmpaq itself the version is easily retrieved from there, very cheap and difficult to get into an error.

The tricky part comes when running setup.py. It should not fail, but if it does, it happens when the developer is using it, so it's not critical.