### PR TITLE
Add 'include' and 'exclude' configuration options to have control on what is inside the packed file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The **packing phase** is executed by the project developer, only once, before di
 
 In this packing phase, PyEmpaq builds the indicated packed file, putting inside:
 
-- the payload project, with all the indicated modules and binary files (currently *everything from the project*, but this will be improved in the future)
+- the payload project, with all the indicated modules and binary files
 
 - an *unpacker* script from PyEmpaq, which will be run during the execution phase
 
@@ -111,7 +111,7 @@ The following is the structure of the `pyempaq.yaml` configuration file:
 
 - `name` [mandatory]: the name of the project.
 
-- `basedir` [optional, defaults to where the configuration file is located]: the project's base directory.
+- `basedir` [optional]: the project's base directory; if not included it defaults to where the configuration file is located.
 
 - `exec` [mandatory]: the section where is defined the information to execute the project once unpacked; it holds different subkeys (some subkeys are marked with †: ONE of those keys must be present, but only ONE):
 
@@ -123,11 +123,17 @@ The following is the structure of the `pyempaq.yaml` configuration file:
 
     - `default-args` [optional]: the default arguments to be passed to the script/module/entrypoint (if not overriden when the distributed `.pyz` is executed).
 
-- `requirements`: a list of filepaths pointing to the requirement files with pip-installable dependencies.
+- `requirements` [optional]: a list of filepaths pointing to the requirement files with pip-installable dependencies.
 
-- `dependencies`: a list of strings to directly specify packages to be installed by `pip` without needing to have a requirement file.
+- `dependencies` [optional]: a list of strings to directly specify packages to be installed by `pip` without needing to have a requirement file.
+
+- `include` [optional]: a list of strings, each one specifying a pattern to decide what files and directories to include in the pack (see below); if not included it defaults to `["./**"]` which means all the files and directories in the project.
+
+- `exclude` [optional]: a list of strings, each one specifying a pattern to decide what files and directories to exclude from the pack (see below).
 
 All specified filepaths must exist inside the project and must be relative (to the project's base directory), with the exception of `basedir` itself which can be absolute or relative (to the configuration file location).
+
+Both `include` and `exclude` options use pattern matching according to the rules used by the Unix shell, using `*`, `?`, and character ranges expressed with `[]`. Also `**` will match any files and zero or more directories. For more information or subtleties check the [`glob.glob`](https://docs.python.org/dev/library/glob.html#glob.glob) documentation.
 
 The following are examples of different configuration files (which were the ones used to build the packed examples mentioned before):
 
@@ -164,6 +170,8 @@ PyEmpaq sources come with a small example project if you want to play a little p
 - a `pyempaq.yaml` with the configuration for PyEmpaq.
 
 - a `ep.py` file which is the project's entrypoint; all it does is to inform it started, import the internal module, access the media files, and use the declared dependency, reporting every step.
+
+- a `secrets.txt` file that must not be included in the packed file.
 
 This explores most of the needs of any project. You can try this example, and surely after you will be ready to actually pack any other project you want.
 

--- a/examples/srcproject/pyempaq.yaml
+++ b/examples/srcproject/pyempaq.yaml
@@ -3,3 +3,5 @@ exec:
   script: ep.py
 dependencies:
   - requests
+exclude:
+  - secrets.txt

--- a/examples/srcproject/secrets.txt
+++ b/examples/srcproject/secrets.txt
@@ -1,0 +1,1 @@
+This file must not be packed!

--- a/pyempaq/config_manager.py
+++ b/pyempaq/config_manager.py
@@ -17,6 +17,9 @@ _BASEDIR = None
 # directory where the config is taken from, which is the default for basedir
 _CONFIGDIR = None
 
+# the default include value to get all the project inside
+DEFAULT_INCLUDE_LIST = ["./**"]
+
 
 class ConfigError(Exception):
     """Specific errors found in the config."""
@@ -108,6 +111,8 @@ class Config(ModelConfigDefaults, validate_all=False):
     exec: Executor
     requirements: List[RelativeFile] = []
     dependencies: List[str] = []
+    include: List[str] = DEFAULT_INCLUDE_LIST
+    exclude: List[str] = []
 
     @pydantic.validator("basedir")
     def ensure_basedir(cls, value):

--- a/pyempaq/main.py
+++ b/pyempaq/main.py
@@ -78,7 +78,8 @@ def copy_project(src_dir: Path, dest_dir: Path, include: List[str], exclude: Lis
             else:
                 logger.error("Cannot find nodes for specified pattern: %r", pattern)
 
-        # get all excluded nodes, building the source path so it's comparable below
+        # get all excluded nodes, building the source path so it's
+        # easier comparable in the main loop below
         for pattern in exclude:
             excluded_nodes.update(src_dir / path for path in glob.iglob(pattern, recursive=True))
     finally:

--- a/pyempaq/main.py
+++ b/pyempaq/main.py
@@ -5,15 +5,19 @@
 """Main packer module."""
 
 import argparse
+import errno
+import glob
 import json
 import logging
-import pathlib
+import os
 import shutil
 import tempfile
 import uuid
 import venv
 import zipapp
 from collections import namedtuple
+from pathlib import Path
+from typing import List
 
 from pyempaq import __version__
 from pyempaq.common import find_venv_bin, logged_exec, ExecutionError
@@ -31,7 +35,7 @@ Args = namedtuple("Args", "project_name basedir entrypoint requirement_files")
 
 def get_pip():
     """Ensure an usable version of `pip`."""
-    useful_pip = pathlib.Path("pip3")
+    useful_pip = Path("pip3")
     # try to see if it's already installed
     try:
         logged_exec([useful_pip, "--version"])
@@ -42,21 +46,97 @@ def get_pip():
         return useful_pip
 
     # no useful pip found, let's create a virtualenv and use the one inside
-    tmpdir = pathlib.Path(tempfile.mkdtemp())
+    tmpdir = Path(tempfile.mkdtemp())
     venv.create(tmpdir, with_pip=True)
     useful_pip = find_venv_bin(tmpdir, "pip3")
     return useful_pip
 
 
+def copy_project(src_dir: Path, dest_dir: Path, include: List[str], exclude: List[str]):
+    """Copy/link the selected project content from the source to the destination directory.
+
+    The content is selected with the 'include' list of patterns, minus the 'exclude' ones.
+
+    It works differently for the different node types:
+    - regular files: hard links (unless permission error or cross device)
+    - directories: created
+    - symlinks: respected, validating that they don't link to outside
+    - other types (blocks, mount points, etc): ignored
+    """
+    included_nodes = ["."]  # always the root, to create the destination directory
+    for pattern in include:
+        included_nodes.extend(glob.iglob(pattern, root_dir=src_dir, recursive=True))
+
+    # need to remove all content inside symlinked directories (as that symlink will
+    # be reproduced, so those contents don't need to be particularly handled)
+    symlinked_dirs = set()
+    for node in included_nodes:
+        node = src_dir / node
+        if node.is_dir() and node.is_symlink():
+            symlinked_dirs.add(node)
+    included_nodes = [
+        node for node in included_nodes
+        if not any(parent in symlinked_dirs for parent in (src_dir / node).parents)
+    ]
+
+    # get all excluded nodes, building the source path so it's comparable below
+    excluded_nodes = set()
+    for pattern in exclude:
+        excluded_nodes.update(
+            src_dir / path
+            for path in glob.iglob(pattern, root_dir=src_dir, recursive=True)
+        )
+
+    def _relative(node):
+        """Return str'ed node relative to src_dir, ready to log."""
+        return str(node.relative_to(src_dir))
+
+    for node in included_nodes:
+        src_node = src_dir / node
+        dest_node = dest_dir / node
+
+        if src_node in excluded_nodes:
+            logger.debug("Ignoring excluded node: %r", _relative(src_node))
+            continue
+        if any(parent in excluded_nodes for parent in src_node.parents):
+            logger.debug("Ignoring node because excluded parent: %r", _relative(src_node))
+            continue
+
+        if src_node.is_symlink():
+            real_pointed_node = src_node.resolve()
+            if src_dir not in real_pointed_node.parents:
+                logger.debug(
+                    "Ignoring symlink because targets outside the project: %r -> %r",
+                    _relative(src_node), str(real_pointed_node),
+                )
+                continue
+            relative_link = os.path.relpath(real_pointed_node, src_node.parent)
+            dest_node.symlink_to(relative_link)
+
+        elif src_node.is_dir():
+            dest_node.mkdir(mode=src_node.stat().st_mode, exist_ok=True)
+
+        elif src_node.is_file():
+            try:
+                dest_node.hardlink_to(src_node)
+            except OSError as error:
+                if error.errno != errno.EXDEV and not isinstance(error, PermissionError):
+                    raise
+                shutil.copy2(src_node, dest_node)
+
+        else:
+            logger.debug("Ignoring file because of type: %r", _relative(src_node))
+
+
 def pack(config):
     """Pack."""
-    project_root = pathlib.Path(__file__).parent
-    tmpdir = pathlib.Path(tempfile.mkdtemp())
+    project_root = Path(__file__).parent
+    tmpdir = Path(tempfile.mkdtemp())
     logger.debug("Working in temp dir %r", str(tmpdir))
 
     # copy all the project content inside "orig" in temp dir
     origdir = tmpdir / "orig"
-    shutil.copytree(config.basedir, origdir)
+    copy_project(config.basedir, origdir, config.include, config.exclude)
 
     # copy the common module
     pyempaq_dir = tmpdir / "pyempaq"
@@ -120,7 +200,7 @@ def main():
     """Manage CLI interaction and call pack."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "source", type=pathlib.Path,
+        "source", type=Path,
         help="The source file (pyempaq.yaml) or the directory where to find it.")
     parser.add_argument(
         '-v', '--verbose',

--- a/pyempaq/main.py
+++ b/pyempaq/main.py
@@ -143,7 +143,9 @@ def copy_project(src_dir: Path, dest_dir: Path, include: List[str], exclude: Lis
 
         elif src_node.is_file():
             try:
-                dest_node.hardlink_to(src_node)
+                # XXX Facundo 2023-04-07: we can use simpler `dest_node.hardlink_to(src_node)`
+                # when we stop supporting < 3.10
+                os.link(src_node, dest_node)
             except OSError as error:
                 if error.errno != errno.EXDEV and not isinstance(error, PermissionError):
                     raise

--- a/pyempaq/main.py
+++ b/pyempaq/main.py
@@ -136,7 +136,8 @@ def copy_project(src_dir: Path, dest_dir: Path, include: List[str], exclude: Lis
                 )
                 continue
             relative_link = os.path.relpath(real_pointed_node, src_node.parent)
-            dest_node.symlink_to(relative_link)
+            target_is_dir = real_pointed_node.is_dir()  # needed for Windows
+            dest_node.symlink_to(relative_link, target_is_directory=target_is_dir)
 
         elif src_node.is_dir():
             dest_node.mkdir(mode=src_node.stat().st_mode, exist_ok=True)

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -338,11 +338,13 @@ def test_copyproject_symlink_outside_directory(src, dest, tmp_path, logs):
     assert expected in logs.debug
 
 
-def test_copyproject_weird_filetype(src, dest, logs):
+def test_copyproject_weird_filetype(src, dest, logs, monkeypatch):
     """Ignore whatever is not a regular file, symlink or dir."""
-    socket_path = src / "test-socket"
+    # change into the source directory and just bind the socket there, otherwise
+    # its path will be too long for MacOS (because of the temp dir path used)
+    monkeypatch.chdir(src)
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.bind(str(socket_path))
+    sock.bind("test-socket")
 
     copy_project(src, dest, *DEFAULT_INC_EXC)
 

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -348,3 +348,36 @@ def test_copyproject_weird_filetype(src, dest, logs):
 
     assert not (dest / "test-socket").exists()
     assert "Ignoring file because of type: 'test-socket'" in logs.debug
+
+
+def test_copyproject_specific_file_inside_directory_existing(src, dest):
+    """Include an existing specific file inside a dir."""
+    basedir = src / "base"
+    basedir.mkdir()
+    thefile = basedir / "foo"
+    thefile.touch()
+
+    copy_project(src, dest, ["base/foo"], [])
+
+    destbase = dest / "base"
+    assert destbase.exists()
+    destfile = destbase / "foo"
+    assert destfile.exists()
+    assert destfile.is_file()
+
+
+def test_copyproject_specific_file_inside_directory_missing(src, dest, logs):
+    """Include a missing specific file inside a dir."""
+    copy_project(src, dest, ["missingdir/missingfile"], [])
+    assert "Cannot find nodes for specified pattern: 'missingdir/missingfile'" in logs.error
+
+
+def test_copyproject_specific_file_inside_directory_ignored(src, dest, logs):
+    """Include an existing specific file inside an ignored dir."""
+    basedir = src / "base"
+    basedir.mkdir()
+    thefile = basedir / "foo"
+    thefile.touch()
+
+    copy_project(src, dest, ["base/foo"], ["base"])
+    assert "Ignoring excluded node: 'base'" in logs.debug

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -1,17 +1,24 @@
-# Copyright 2021 Facundo Batista
+# Copyright 2021-2023 Facundo Batista
 # Licensed under the GPL v3 License
 # For further info, check https://github.com/facundobatista/pyempaq
 
 """Tests for some main helpers."""
 
+import errno
+import os
 import pathlib
+import socket
 import sys
 from unittest.mock import patch
 
 import pytest
 
-from pyempaq.main import get_pip
+from pyempaq.main import get_pip, copy_project
 from pyempaq.common import ExecutionError
+from pyempaq.config_manager import DEFAULT_INCLUDE_LIST
+
+
+# -- tests for get pip
 
 
 @pytest.mark.parametrize("version", [
@@ -37,3 +44,307 @@ def test_get_pip_failing_pip(tmp_path):
     # from inside a venv
     assert (
         useful_pip == tmp_path / "bin" / "pip3" or useful_pip == tmp_path / "Scripts" / "pip3.exe")
+
+
+# -- tests for copy project
+
+# the default include/exclude structures, so all tests that work with the default are simpler
+DEFAULT_INC_EXC = DEFAULT_INCLUDE_LIST, []
+
+
+@pytest.fixture
+def src(tmp_path):
+    """Provide an already created source directory."""
+    tmp = tmp_path / "src"
+    tmp.mkdir()
+    yield tmp
+
+
+@pytest.fixture
+def dest(tmp_path):
+    """Provide a not yet created destination directory."""
+    tmp = tmp_path / "dest"
+    yield tmp
+
+
+def test_copyproject_simple_structure(src, dest):
+    """Copy a directory and a file."""
+    (src / "foo").touch()
+    (src / "bar").mkdir()
+    (src / "bar" / "baz").touch()
+
+    copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    foo = dest / "foo"
+    assert foo.exists()
+    assert foo.is_file()
+    bar = dest / "bar"
+    assert bar.exists()
+    assert bar.is_dir()
+    baz = dest / "bar" / "baz"
+    assert baz.exists()
+    assert baz.is_file()
+
+
+def test_copyproject_content_and_metadata(src, dest):
+    """Respect content and metadata."""
+    src_file = (src / "foo")
+    src_file.write_text("test content")
+    src_file.chmod(0o775)
+    src_dir = (src / "bar")
+    src_dir.mkdir(mode=0o700)
+
+    copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    dest_file = dest / "foo"
+    assert dest_file.is_file()
+    assert dest_file.read_text() == "test content"
+    assert dest_file.stat().st_mode == src_file.stat().st_mode
+    dest_dir = dest / "bar"
+    assert dest_dir.is_dir()
+    assert dest_dir.stat().st_mode == src_dir.stat().st_mode
+
+
+def test_copyproject_hidden_default_ignored(src, dest):
+    """Do not include hidden directories or files by default."""
+    (src / ".foo").touch()
+    (src / ".bar").mkdir()
+
+    copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    assert list(dest.iterdir()) == []
+
+
+def test_copyproject_hidden_included_if_specified(src, dest):
+    """Do include hidden directories and files if specified."""
+    (src / ".foo").touch()
+    (src / ".bar").mkdir()
+
+    include = ["./.*"]
+    exclude = []
+    copy_project(src, dest, include, exclude)
+
+    assert set(dest.iterdir()) == {dest / ".foo", dest / ".bar"}
+
+
+def test_copyproject_ignore_excluded_nodes(src, dest, logs):
+    """Do not include an excluded file or directory."""
+    (src / "foo_file").touch()
+    (src / "foo_dir").mkdir()
+    (src / "bar_file").touch()
+    (src / "bar_dir").mkdir()
+
+    include = DEFAULT_INCLUDE_LIST
+    exclude = ["foo*"]
+    copy_project(src, dest, include, exclude)
+
+    assert set(dest.iterdir()) == {dest / "bar_file", dest / "bar_dir"}
+    assert "Ignoring excluded node: 'foo_file'" in logs.debug
+    assert "Ignoring excluded node: 'foo_dir'" in logs.debug
+
+
+def test_copyproject_ignore_excluded_parent(src, dest, logs):
+    """Do not include a node if the parent is excluded."""
+    foo_dir = src / "foo_dir"
+    foo_dir.mkdir()
+    (foo_dir / "foo_file").touch()
+    bar_dir = src / "bar_dir"
+    bar_dir.mkdir()
+    (bar_dir / "bar_file").touch()
+
+    include = DEFAULT_INCLUDE_LIST
+    exclude = ["foo_dir"]
+    copy_project(src, dest, include, exclude)
+
+    assert (dest / "bar_dir").exists()
+    assert (dest / "bar_dir" / "bar_file").exists()
+    assert "Ignoring excluded node: 'foo_dir'" in logs.debug
+    assert "Ignoring node because excluded parent: 'foo_dir/foo_file'" in logs.debug
+
+
+def test_copyproject_include_nothing(src, dest):
+    """Support nothing being included."""
+    (src / "foo").touch()
+
+    include = []
+    exclude = []
+    copy_project(src, dest, include, exclude)
+
+    assert list(dest.iterdir()) == []
+
+
+def test_copyproject_deeptree(src, dest):
+    """Sanity check for a deep tree."""
+    # create this structure:
+    # ├─ file1.txt
+    # ├─ dir1
+    # │  └─ secret1  (ignored!)
+    # └─ dir2
+    #    ├─ file2.txt
+    #    ├─ secret2.txt  (ignored!)
+    #    ├─ cache  (ignored!)
+    #    │   └─ file3.txt
+    #    └─ dir3
+    file1 = src / "file1.txt"
+    file1.touch()
+    dir1 = src / "dir1"
+    dir1.mkdir()
+    secret1 = dir1 / "secret1"
+    secret1.touch()
+    dir2 = src / "dir2"
+    dir2.mkdir()
+    file2 = dir2 / "file2.txt"
+    file2.touch()
+    secret2 = dir2 / "secret2.txt"
+    secret2.touch()
+    cache = dir2 / "cache"
+    cache.mkdir()
+    file3 = cache / "file3.txt"
+    file3.touch()
+    dir3 = dir2 / "dir3"
+    dir3.mkdir()
+
+    include = DEFAULT_INCLUDE_LIST
+    exclude = ["**/secret*", "dir2/cache"]
+    copy_project(src, dest, include, exclude)
+
+    assert (dest / "file1.txt").exists()
+    assert (dest / "dir1").exists()
+    assert not (dest / "dir1" / "secret1").exists()
+    assert (dest / "dir2").exists()
+    assert (dest / "dir2" / "file2.txt").exists()
+    assert not (dest / "dir2" / "secret2.txt").exists()
+    assert not (dest / "dir2" / "cache").exists()
+    assert (dest / "dir2" / "dir3").exists()
+
+
+def test_copyproject_no_link_permission(src, dest):
+    """The platform does not allow hard links."""
+    src_file = src / "foo"
+    src_file.write_text("test content")
+    src_file.chmod(0o775)
+
+    with patch("pathlib.Path.hardlink_to", side_effect=PermissionError("No you don't.")):
+        copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    dest_file = dest / "foo"
+    assert dest_file.is_file()
+    assert dest_file.read_text() == "test content"
+    assert dest_file.stat().st_mode == src_file.stat().st_mode
+
+
+def test_copyproject_cross_device(src, dest):
+    """Hard links cannot be done from one device to other."""
+    src_file = src / "foo"
+    src_file.write_text("test content")
+    src_file.chmod(0o775)
+
+    os_error = OSError(errno.EXDEV, os.strerror(errno.EXDEV))
+    with patch("pathlib.Path.hardlink_to", side_effect=os_error):
+        copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    dest_file = dest / "foo"
+    assert dest_file.is_file()
+    assert dest_file.read_text() == "test content"
+    assert dest_file.stat().st_mode == src_file.stat().st_mode
+
+
+def test_copyproject_symlink_file(src, dest):
+    """Respect a symlinked file."""
+    real_file = src / "foo"
+    real_file.touch()
+    src_symlink = src / "bar"
+    src_symlink.symlink_to(real_file)
+
+    copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    dest_symlink = dest / "bar"
+    assert dest_symlink.is_symlink()
+    assert dest_symlink.resolve() == dest / "foo"
+    real_link = os.readlink(dest_symlink)
+    assert real_link == "foo"
+
+
+def test_copyproject_symlink_dir(src, dest):
+    """Respect a symlinked dir."""
+    real_dir = src / "foodir"
+    real_dir.mkdir()
+    real_file = real_dir / "foofile"
+    real_file.touch()
+    src_symlink = src / "bar"
+    src_symlink.symlink_to(real_dir)
+
+    copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    dest_symlink = dest / "bar"
+    assert dest_symlink.is_symlink()
+    assert dest_symlink.resolve() == dest / "foodir"
+    real_link = os.readlink(dest_symlink)
+    assert real_link == "foodir"
+
+    # the file inside the linked dir should exist
+    assert (dest / "bar" / "foofile").exists()
+
+
+def test_copyproject_symlink_deep(src, dest):
+    """Sanity check for symbolic links from one deep dir to other."""
+    real_dir_1 = src / "dir1"
+    real_dir_1.mkdir()
+    real_dir_2 = src / "dir2"
+    real_dir_2.mkdir()
+    real_file = real_dir_1 / "real_file"
+    real_file.touch()
+    src_symlink = real_dir_2 / "the_link"
+    src_symlink.symlink_to(real_file)
+
+    copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    dest_symlink = dest / "dir2" / "the_link"
+    assert dest_symlink.is_symlink()
+    assert dest_symlink.resolve() == dest / "dir1" / "real_file"
+    real_link = os.readlink(dest_symlink)
+    assert real_link == "../dir1/real_file"
+
+
+def test_copyproject_symlink_outside_file(src, dest, tmp_path, logs):
+    """Ignore a symlink pointing to outside the root directory, case for a file."""
+    out_dir = tmp_path / "outside"
+    out_dir.mkdir()
+    out_file = out_dir / "secrets"
+    out_file.touch()
+
+    src_symlink = src / "foo"
+    src_symlink.symlink_to(out_file)
+
+    copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    assert not (dest / "foo").exists()
+    expected = f"Ignoring symlink because targets outside the project: 'foo' -> {str(out_file)!r}"
+    assert expected in logs.debug
+
+
+def test_copyproject_symlink_outside_directory(src, dest, tmp_path, logs):
+    """Ignore a symlink pointing to outside the root directory, case for a dir."""
+    out_dir = tmp_path / "outside"
+    out_dir.mkdir()
+
+    src_symlink = src / "foo"
+    src_symlink.symlink_to(out_dir)
+
+    copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    assert not (dest / "foo").exists()
+    expected = f"Ignoring symlink because targets outside the project: 'foo' -> {str(out_dir)!r}"
+    assert expected in logs.debug
+
+
+def test_copyproject_weird_filetype(src, dest, logs):
+    """Ignore whatever is not a regular file, symlink or dir."""
+    socket_path = src / "test-socket"
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(str(socket_path))
+
+    copy_project(src, dest, *DEFAULT_INC_EXC)
+
+    assert not (dest / "test-socket").exists()
+    assert "Ignoring file because of type: 'test-socket'" in logs.debug

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -385,4 +385,5 @@ def test_copyproject_specific_file_inside_directory_ignored(src, dest, logs):
     thefile.touch()
 
     copy_project(src, dest, ["base/foo"], ["base"])
-    assert "Ignoring excluded node: 'base'" in logs.debug
+    excluded = os.path.join("base", "foo")
+    assert Exact(f"Ignoring node because excluded parent: {excluded!r}") in logs.debug

--- a/tests/test_main_helpers.py
+++ b/tests/test_main_helpers.py
@@ -224,7 +224,7 @@ def test_copyproject_no_link_permission(src, dest):
     src_file.write_text("test content")
     src_file.chmod(0o775)
 
-    with patch("pathlib.Path.hardlink_to", side_effect=PermissionError("No you don't.")):
+    with patch("os.link", side_effect=PermissionError("No you don't.")):
         copy_project(src, dest, *DEFAULT_INC_EXC)
 
     dest_file = dest / "foo"
@@ -240,7 +240,7 @@ def test_copyproject_cross_device(src, dest):
     src_file.chmod(0o775)
 
     os_error = OSError(errno.EXDEV, os.strerror(errno.EXDEV))
-    with patch("pathlib.Path.hardlink_to", side_effect=os_error):
+    with patch("os.link", side_effect=os_error):
         copy_project(src, dest, *DEFAULT_INC_EXC)
 
     dest_file = dest / "foo"


### PR DESCRIPTION
Fixes #6.