### PR TITLE
exit pyempaq using the unpacked script exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ In this execution phase, the *unpacker* script put by PyEmpaq inside the packed 
 
 The verification that the unpacker does to see if has a reusable setup from the past is based on the `.pyz` timestamp; if it changed (a new file was distributed), a new setup will be created and used.
 
+PyEmpaq transparently returns the payload's exit code except when it must exit before the execution of the payload.
+In that case, it uses special codes equal or above 64, see below for their meaning.
+
+- `64`: `unpack-restrictions` are not met on the final user's system.
+
 
 ## Command line options
 

--- a/pyempaq/unpacker.py
+++ b/pyempaq/unpacker.py
@@ -69,7 +69,7 @@ def build_command(python_exec: str, metadata: Dict[str, str], sys_args: List[str
     return cmd
 
 
-def run_command(venv_bin_dir: pathlib.Path, cmd: List[str]) -> None:
+def run_command(venv_bin_dir: pathlib.Path, cmd: List[str]) -> int:
     """Run the command with a custom context."""
     newenv = os.environ.copy()
     venv_bin_dir_str = str(venv_bin_dir)
@@ -78,7 +78,7 @@ def run_command(venv_bin_dir: pathlib.Path, cmd: List[str]) -> None:
     else:
         newenv["PATH"] = venv_bin_dir_str
     newenv["PYEMPAQ_PYZ_PATH"] = os.path.dirname(__file__)
-    subprocess.run(cmd, env=newenv)
+    return subprocess.run(cmd, env=newenv).returncode
 
 
 def setup_project_directory(
@@ -191,8 +191,10 @@ def run():
     cmd = build_command(str(python_exec), metadata, sys.argv[1:])
     log("Running payload: %s", cmd)
     venv_bin_dir = python_exec.parent
-    run_command(venv_bin_dir, cmd)
+    code = run_command(venv_bin_dir, cmd)
+    log("Exit code: %s", code)
     log("PyEmpaq done")
+    exit(code)
 
 
 if __name__ == "__main__":

--- a/pyempaq/unpacker.py
+++ b/pyempaq/unpacker.py
@@ -69,7 +69,7 @@ def build_command(python_exec: str, metadata: Dict[str, str], sys_args: List[str
     return cmd
 
 
-def run_command(venv_bin_dir: pathlib.Path, cmd: List[str]) -> int:
+def run_command(venv_bin_dir: pathlib.Path, cmd: List[str]) -> subprocess.CompletedProcess:
     """Run the command with a custom context."""
     newenv = os.environ.copy()
     venv_bin_dir_str = str(venv_bin_dir)
@@ -78,7 +78,7 @@ def run_command(venv_bin_dir: pathlib.Path, cmd: List[str]) -> int:
     else:
         newenv["PATH"] = venv_bin_dir_str
     newenv["PYEMPAQ_PYZ_PATH"] = os.path.dirname(__file__)
-    return subprocess.run(cmd, env=newenv).returncode
+    return subprocess.run(cmd, env=newenv)
 
 
 def setup_project_directory(
@@ -191,10 +191,10 @@ def run():
     cmd = build_command(str(python_exec), metadata, sys.argv[1:])
     log("Running payload: %s", cmd)
     venv_bin_dir = python_exec.parent
-    code = run_command(venv_bin_dir, cmd)
-    log("Exit code: %s", code)
+    proc = run_command(venv_bin_dir, cmd)
+    log("Exit code: %s", proc.returncode)
     log("PyEmpaq done")
-    exit(code)
+    exit(proc.returncode)
 
 
 if __name__ == "__main__":

--- a/pyempaq/unpacker.py
+++ b/pyempaq/unpacker.py
@@ -28,6 +28,11 @@ PROJECT_VENV_DIR = "project_venv"
 # the file name to flag that the project setup completed successfully
 COMPLETE_FLAG_FILE = "complete.flag"
 
+# special exit codes returned by the unpacker
+EXIT_CODES = {
+    "restrictions_not_met": 64
+}
+
 # setup logging
 logger = logging.getLogger()
 handler = logging.StreamHandler()
@@ -172,7 +177,7 @@ def run():
     from packaging import version  # NOQA
 
     if not restrictions_ok(version, metadata["unpack_restrictions"]):
-        exit(1)
+        exit(EXIT_CODES["restrictions_not_met"])
 
     pyempaq_dir = pathlib.Path(platformdirs.user_data_dir()) / 'pyempaq'
     pyempaq_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_unpacker.py
+++ b/tests/test_unpacker.py
@@ -8,6 +8,7 @@ import os
 import platform
 import zipfile
 from pathlib import Path
+from subprocess import CompletedProcess
 from unittest.mock import patch
 
 import pytest
@@ -125,6 +126,17 @@ def test_runcommand_pyz_path():
     (call1,) = run_mock.call_args_list
     passed_env = call1[1]["env"]
     assert passed_env["PYEMPAQ_PYZ_PATH"] == os.path.dirname(pyempaq.unpacker.__file__)
+
+
+def test_runcommand_returns_exit_code():
+    """Check the completed process is returned."""
+    cmd = ["foo", "bar"]
+    code = 1
+    with patch("subprocess.run") as run_mock:
+        run_mock.return_value = CompletedProcess(cmd, code)
+        proc = run_command(Path("test-venv-dir"), cmd)
+        assert proc.args == cmd
+        assert proc.returncode == code
 
 
 # --- tests for the project directory setup


### PR DESCRIPTION
Hello @facundobatista,

I'm using `pyempaq` to pack a cli and wanted to be able to check its meaningful exit code so I can create shell scripts around it.
Currently when my cli crashes, I can see the traceback (as stdout/stderr are not captured) but it always exits with code `0`.

I would like to know if you are agree to return the exit code of the unpacked script ?

This is what this PR is currently doing.

I thought also that maybe you would want to differentiate unpack errors from user's script ones using a special code ? (there is one `exit(1)` when `unpack_restrictions` are not ok)

Seems also related to #64 

(thank you for this useful project !)