### PR TITLE
always include requirements in the pack

### DIFF
--- a/pyempaq/common.py
+++ b/pyempaq/common.py
@@ -15,6 +15,10 @@ class ExecutionError(Exception):
     """The subprocess didn't finish ok."""
 
 
+class PackError(Exception):
+    """An error occurred while packing the project."""
+
+
 def find_venv_bin(basedir, exec_base):
     """Heuristics to find the pip executable in different platforms."""
     bin_dir = basedir / "bin"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -173,15 +173,13 @@ def test_pack_with_requirements(tmp_path, monkeypatch, extraconf):
     """Test pack with provided requirements works."""
     projectpath = tmp_path / "fakeproject"
     projectpath.mkdir()
-    reqs = ["req1.txt", "req2.txt"]
-    for req in reqs:
-        # don't include a package to speedup the test
-        (projectpath / req).touch()
-    (projectpath / "main.py").write_text("print('ok')")
+    (projectpath / "req1.txt").write_text("requests")
+    (projectpath / "req2.txt").touch()
+    (projectpath / "main.py").write_text("import requests;print('ok')")
     conf = {
         "name": "testproject",
         "basedir": str(projectpath),
-        "requirements": reqs,
+        "requirements": ["req1.txt", "req2.txt"],
         "exec": {
             "script": "main.py"
         },


### PR DESCRIPTION
Hi @facundobatista 

I've found that pyempaq can fail to unpack a pack when using `requirements` along with `include`
or `exclude` depending on the user's configuration.

Currently requirements are included thanks to the default include's configuration `./**`.
If users are not including them explicitly or if they are excluding them, requirements might not be in the pack leading to the unpacker crashing.

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/me/pyempaq/req.pyz/__main__.py", line 206, in <module>
  File "/home/me/pyempaq/req.pyz/__main__.py", line 191, in run
  File "/home/me/pyempaq/req.pyz/__main__.py", line 135, in setup_project_directory
  File "/home/.local/lib/python3.10/site-packages/pyempaq/common.py", line 49, in logged_exec
    raise ExecutionError(f"Command {cmd} ended with retcode {retcode}")
pyempaq.common.ExecutionError: Command ['/home//.local/share/pyempaq/req-20230619161451/project_venv/bin/pip3', 'install', '-r', '/home/.local/share/pyempaq/req-20230619161451/orig/requirements.txt'] ended with retcode 1
````

When executing manually this command, I've got
`ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/home/.local/share/pyempaq/req-20230619161451/orig/requirements.txt`

example of problematic configuration:

```yaml
name: req
exec:
  script: main.py
requirements:
  - requirements.txt
include:
  - main.py
#   - requirements.txt
```

To me, requirements are "owned" by pyempaq as it installs them in a transparent way for users.

My PR ensures the requirements are always included whatever the user's configuration, as otherwise they can shoot themselves in the foot.

I've added tests in `test_integration.py` as there is already the tooling available to test the pack, not sure it is okay for you.

I haven't added a note in the docs as, to me, the correct behavior is described.

Let me know if the approach I've taken seems good to you !
