### PR TITLE
Refactor the project's install directory name.

### DIFF
--- a/pyempaq/unpacker.py
+++ b/pyempaq/unpacker.py
@@ -29,6 +29,10 @@ PROJECT_VENV_DIR = "project_venv"
 # the file name to flag that the project setup completed successfully
 COMPLETE_FLAG_FILE = "complete.flag"
 
+# the real magic number is a byte sequence with "\r\n" at the end; it's built here
+# so it's easily patchable by tests
+MAGIC_NUMBER = importlib.util.MAGIC_NUMBER[:-2].hex()
+
 # setup logging
 logger = logging.getLogger()
 handler = logging.StreamHandler()
@@ -173,9 +177,8 @@ def build_project_install_dir(zip_path: pathlib.Path, metadata: Dict[str, str]):
     # Python details
     py_impl = platform.python_implementation().lower()
     py_version = ".".join(platform.python_version_tuple()[:2])
-    py_magic = importlib.util.MAGIC_NUMBER.strip().decode("ascii")
 
-    name = f"{project_name}-{file_hash_partial}-{py_impl}.{py_version}.{py_magic}"
+    name = f"{project_name}-{file_hash_partial}-{py_impl}.{py_version}.{MAGIC_NUMBER}"
     return name
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,5 @@ logassert
 packaging
 pydocstyle
 pytest
+pytest-mock
 pytest-subprocess

--- a/tests/test_unpacker.py
+++ b/tests/test_unpacker.py
@@ -4,6 +4,8 @@
 
 """Unpacker tests."""
 
+import hashlib
+import importlib
 import os
 import platform
 import zipfile
@@ -18,6 +20,7 @@ import pyempaq.unpacker
 from pyempaq.unpacker import (
     PROJECT_VENV_DIR,
     build_command,
+    build_project_install_dir,
     restrictions_ok,
     run_command,
     setup_project_directory,
@@ -279,3 +282,24 @@ def test_enforcerestrictions_pythonversion_good_comparison(logs):
     """Enforce minimum python version using a proper comparison, not strings."""
     ok = restrictions_ok(version, {"minimum_python_version": "3.0009"})
     assert ok is True
+
+
+# --- tests for the project install dir name
+
+
+def test_installdirname_complete(mocker, tmp_path):
+    """Check the name is properly built."""
+    mocker.patch("platform.python_implementation", return_value="PyPy")
+    mocker.patch("platform.python_version_tuple", return_value=("3", "18", "7alpha"))
+
+    zip_path = tmp_path / "somestuff.zip"
+    content = b"some content to be hashed"
+    zip_path.write_bytes(content)
+    content_hash = hashlib.sha256(content).hexdigest()
+
+    fake_metadata = {"foo": "bar", "project_name": "testproj"}
+
+    dirname = build_project_install_dir(zip_path, fake_metadata)
+
+    magic = importlib.util.MAGIC_NUMBER.strip().decode("ascii")  # scared to patch this one
+    assert dirname == f"testproj-{content_hash[:20]}-pypy.3.18.{magic}"

--- a/tests/test_unpacker.py
+++ b/tests/test_unpacker.py
@@ -5,7 +5,6 @@
 """Unpacker tests."""
 
 import hashlib
-import importlib
 import os
 import platform
 import zipfile
@@ -291,6 +290,7 @@ def test_installdirname_complete(mocker, tmp_path):
     """Check the name is properly built."""
     mocker.patch("platform.python_implementation", return_value="PyPy")
     mocker.patch("platform.python_version_tuple", return_value=("3", "18", "7alpha"))
+    mocker.patch("pyempaq.unpacker.MAGIC_NUMBER", "xyz")
 
     zip_path = tmp_path / "somestuff.zip"
     content = b"some content to be hashed"
@@ -301,5 +301,4 @@ def test_installdirname_complete(mocker, tmp_path):
 
     dirname = build_project_install_dir(zip_path, fake_metadata)
 
-    magic = importlib.util.MAGIC_NUMBER.strip().decode("ascii")  # scared to patch this one
-    assert dirname == f"testproj-{content_hash[:20]}-pypy.3.18.{magic}"
+    assert dirname == f"testproj-{content_hash[:20]}-pypy.3.18.xyz"


### PR DESCRIPTION
This now includes Python version and other metadata, and the hash of the zip file instead of its timestamp. 

Fixes #58 .