### PR TITLE
Incorporate two special actions: info and uninstall.

### DIFF
--- a/pyempaq/unpacker.py
+++ b/pyempaq/unpacker.py
@@ -35,6 +35,9 @@ COMPLETE_FLAG_FILE = "complete.flag"
 # so it's easily patchable by tests
 MAGIC_NUMBER = importlib.util.MAGIC_NUMBER[:-2].hex()
 
+# the environment variable to specify a different action
+ACTION_ENVVAR = "PYEMPAQ_ACTION"
+
 # setup logging
 logger = logging.getLogger()
 handler = logging.StreamHandler()
@@ -58,10 +61,47 @@ class FatalError(Exception):
         restrictions_not_met = 64
         unpack_basedir_missing = 65
         unpack_basedir_notdir = 66
+        bad_action = 67
 
     def __init__(self, code):
         self.returncode = code
         super().__init__("")
+
+
+# -- special PyEmpaq actions
+
+def special_action_info(pyempaq_dir, metadata):
+    """Provide information about different installations for the project."""
+    print("Base PyEmpaq directory:", pyempaq_dir)
+    subdirs = sorted(pyempaq_dir.glob(f"{metadata['project_name']}-*"))
+    if not subdirs:
+        print("No installation found!")
+        return
+
+    print("Current installations:")
+    for subdir in subdirs:
+        print("   ", subdir.name)
+
+
+def special_action_uninstall(pyempaq_dir, metadata):
+    """Remove all installations for the given project."""
+    subdirs = list(pyempaq_dir.glob(f"{metadata['project_name']}-*"))
+    if not subdirs:
+        print("No installation found!")
+        return
+
+    print("Removing installation:")
+    for subdir in subdirs:
+        print("   ", subdir.name)
+        shutil.rmtree(subdir)
+
+
+ACTION_CHOICES = {
+    "info": special_action_info,
+    "uninstall": special_action_uninstall,
+}
+
+# --
 
 
 def get_python_exec(project_dir: pathlib.Path) -> pathlib.Path:
@@ -264,6 +304,19 @@ def run():
 
     pyempaq_dir = get_base_dir(platformdirs)
     logger.info("Base directory: %r", str(pyempaq_dir))
+
+    indicated_action = os.environ.get(ACTION_ENVVAR)
+    if indicated_action is not None:
+        indicated_action = indicated_action.lower()
+        print(f"Running {indicated_action!r} action")
+        try:
+            func = ACTION_CHOICES[indicated_action]
+        except KeyError:
+            logger.error(
+                "Bad specified action %s=%r; valid options: %s",
+                ACTION_ENVVAR, indicated_action, ", ".join(ACTION_CHOICES.keys()))
+            raise FatalError(FatalError.ReturnCode.bad_action)
+        return func(pyempaq_dir, metadata)
 
     # create a temp dir and extract the project there
     project_dir = pyempaq_dir / build_project_install_dir(pyempaq_filepath, metadata)

--- a/pyempaq/unpacker.py
+++ b/pyempaq/unpacker.py
@@ -85,7 +85,7 @@ def special_action_info(pyempaq_dir, metadata):
 
 def special_action_uninstall(pyempaq_dir, metadata):
     """Remove all installations for the given project."""
-    subdirs = list(pyempaq_dir.glob(f"{metadata['project_name']}-*"))
+    subdirs = sorted(pyempaq_dir.glob(f"{metadata['project_name']}-*"))
     if not subdirs:
         print("No installation found!")
         return

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,7 @@ import textwrap
 import pytest
 import yaml
 
-from pyempaq.unpacker import FatalError, ACTION_ENVVAR, get_file_hexdigest
+from pyempaq.unpacker import FatalError, ACTION_ENVVAR, build_project_install_dir
 
 
 def _pack(tmp_path, monkeypatch, config_text):
@@ -297,6 +297,7 @@ def test_action_info(tmp_path, monkeypatch):
         exec:
           script: ep.py
     """)
+    install_dirname = build_project_install_dir(packed_filepath, {"project_name": "testproject"})
 
     # unpack it once so it's already installed
     proc, run_path = _unpack(packed_filepath, tmp_path, expected_rc=0)
@@ -307,12 +308,11 @@ def test_action_info(tmp_path, monkeypatch):
     proc, run_path = _unpack(packed_filepath, tmp_path, expected_rc=0, extra_env=extra_env)
     assert proc.returncode == 0
 
-    hexdigest = get_file_hexdigest(packed_filepath)
     assert proc.stdout == textwrap.dedent(f"""\
         Running 'info' action
         Base PyEmpaq directory: {tmp_path}
         Current installations:
-            testproject-{hexdigest[:20]}-cpython.3.10.6f0d
+            {install_dirname}
     """)
 
 
@@ -330,6 +330,7 @@ def test_action_uninstall(tmp_path, monkeypatch):
         exec:
           script: ep.py
     """)
+    install_dirname = build_project_install_dir(packed_filepath, {"project_name": "testproject"})
 
     # unpack it once so it's already installed
     proc, run_path = _unpack(packed_filepath, tmp_path, expected_rc=0)
@@ -342,9 +343,8 @@ def test_action_uninstall(tmp_path, monkeypatch):
     assert proc.returncode == 0
     assert len(list(tmp_path.glob("testproject-*"))) == 0
 
-    hexdigest = get_file_hexdigest(packed_filepath)
     assert proc.stdout == textwrap.dedent(f"""\
         Running 'uninstall' action
         Removing installation:
-            testproject-{hexdigest[:20]}-cpython.3.10.6f0d
+            {install_dirname}
     """)


### PR DESCRIPTION
Info is on purpose only listing what directories are there (which already provide some info with the name), nothing else; maybe in the future we'll incorporate more data (e.g. `pip freeze`) but it's not clear if it's useful, so let's just not bloat it.

Fixes #59.